### PR TITLE
[FIX] CFN output not showing publicly resolvable url for Cruisecontrol

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The CloudFormation template itself streamlines the deployment process by automat
   - [`prometheus.yml`](config/prometheus.yml) (Prometheus configuration).
   - [`capacityCores.json`](config/capacityCores.json) (Cruise Control capacity configuration).
 - An EC2 security group that has access to your target MSK cluster. The simplest approach would be to use the same security group attached to your MSK cluster, which includes a self-referencing inbound rule allowing all traffic.
+- The MSK security group should also have inbound rule to port 11001 and 11002 from the security group attached to the cruise control instance.
 
 ## Parameters
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,10 @@ The CloudFormation template itself streamlines the deployment process by automat
 - An existing Amazon MSK Kafka cluster.
 - Enable open monitoring with [Prometheus] (https://docs.aws.amazon.com/msk/latest/developerguide/open-monitoring.html).
 - An S3 bucket with the following files:
-  - [`targets.json`](config/targets.json) (Prometheus targets configuration).
+  - [`targets.json`](config/targets.json) (Prometheus targets configuration). Replace the broker endpoints with yout MSK cluster broker endpoints.
   - [`prometheus.yml`](config/prometheus.yml) (Prometheus configuration).
-  - [`capacityCores.json`](config/capacityCores.json) (Cruise Control capacity configuration).
+  - [`capacityCores.json`](config/capacityCores.json) (Cruise Control capacity configuration). Add configuration for all brokers. Set configuration for each brokerId - 0,1,2 etc... 
+
 - An EC2 security group that has access to your target MSK cluster. The simplest approach would be to use the same security group attached to your MSK cluster, which includes a self-referencing inbound rule allowing all traffic.
 - The MSK security group should also have inbound rule to port 11001 and 11002 from the security group attached to the cruise control instance.
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The CloudFormation template itself streamlines the deployment process by automat
 - An S3 bucket with the following files:
   - [`targets.json`](config/targets.json) (Prometheus targets configuration). Replace the broker endpoints with yout MSK cluster broker endpoints.
   - [`prometheus.yml`](config/prometheus.yml) (Prometheus configuration).
-  - [`capacityCores.json`](config/capacityCores.json) (Cruise Control capacity configuration). Add configuration for all brokers. Set configuration for each brokerId - 0,1,2 etc... 
+  - [`capacityCores.json`](config/capacityCores.json) (Cruise Control capacity configuration).
 
 - An EC2 security group that has access to your target MSK cluster. The simplest approach would be to use the same security group attached to your MSK cluster, which includes a self-referencing inbound rule allowing all traffic.
 - The MSK security group should also have inbound rule to port 11001 and 11002 from the security group attached to the cruise control instance.

--- a/msk-cruise-control-deploy.yaml
+++ b/msk-cruise-control-deploy.yaml
@@ -193,7 +193,7 @@ Outputs:
       - - 'http://'
         - !GetAtt 
           - WebServerInstance
-          - PrivateIp
+          - PublicDnsName
         - ':9090'
   CruiseControlURL:
     Description: URL for Cruise control web UI
@@ -202,5 +202,5 @@ Outputs:
       - - 'http://'
         - !GetAtt 
           - WebServerInstance
-          - PrivateIp
+          - PublicDnsName
         - ':9091'


### PR DESCRIPTION
*Issue #, if available:*

CFN output is showing PrivateIP. Changed that to PublicDNS and updated README

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
